### PR TITLE
create the `salty` command (select until)

### DIFF
--- a/atom.py
+++ b/atom.py
@@ -17,6 +17,7 @@ COMMANDS = Struct(
     FIND_PREVIOUS = 'p',
     COPY_LINE = 'c',
     MOVE_LINE = 'm',
+    SELECT_UNTIL = 'u',
 )
 
 ############## support for parsing numbers as command postfix
@@ -128,6 +129,10 @@ def select_lines(m):
     line_range = text_to_number(m)
     execute_atom_command(COMMANDS.SELECT_LINES, str(line_range))
 
+def select_until(m):
+    line = text_to_number(m)
+    execute_atom_command(COMMANDS.SELECT_UNTIL, str(line))
+
 keymap = {
     'sprinkle' + optional_numerals: jump_to_bol,
     'spring' + optional_numerals: jump_to_eol_and(jump_to_beginning_of_text),
@@ -154,6 +159,7 @@ keymap = {
 
     'shackle': Key('cmd-l'),
     'selrang' + numerals: select_lines,
+    'salty' + numerals: select_until,
 
     'shockey': Key('cmd-shift-enter'),
     'shockoon': Key('cmd-right enter'),

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -7,6 +7,7 @@ const commandNames = {
   FIND_PREVIOUS: 'p',
   COPY_LINE: 'c',
   MOVE_LINE: 'm',
+  SELECT_UNTIL: 'u',
 }
 
 let editor
@@ -102,5 +103,20 @@ module.exports[commandNames.SELECT_LINES] = () => {
     getEditor()
     const lineRange = calculateLineRange(lineRangeString)
     editor.setSelectedBufferRange([[lineRange.from - 1, 0], [lineRange.to, 0]])
+  }
+}
+module.exports[commandNames.SELECT_UNTIL] = () => {
+  return line => {
+    getEditor()
+    var from = editor.getCursorBufferPosition()
+    jumpLine = parseInt(line, 10)
+    to = [jumpLine, 0]
+    if(from.row > to[0]) {
+      tmp = from
+      from = to
+      to = tmp
+      from[0] = from[0] - 1
+    }
+    editor.setSelectedBufferRange([from, to])
   }
 }


### PR DESCRIPTION
usage: `salty 334` selects from where the cursor is to line 334.